### PR TITLE
Add back link

### DIFF
--- a/app/views/raiserepair/book-appointment-contact.html
+++ b/app/views/raiserepair/book-appointment-contact.html
@@ -33,7 +33,7 @@
       <p>We will send you a text reminder before your repair appointment.<p>
 
         <div class="form-group">
-          <input class="button" type="submit" value="Confirm and book a repair">
+          <input class="button" type="submit" value="Confirm and book this appointment">
         </div>
       </form>
 

--- a/app/views/raiserepair/book-appointment-contact.html
+++ b/app/views/raiserepair/book-appointment-contact.html
@@ -30,12 +30,16 @@
         <input class="form-control" id="telephone-number" type="number" name="telephone-number" required>
       </div>
 
-      <p>We will send you a reminder before your appointment.<p>
+      <p>We will send you a text reminder before your repair appointment.<p>
 
         <div class="form-group">
-          <input class="button" type="submit" value="Continue">
+          <input class="button" type="submit" value="Confirm and book a repair">
         </div>
       </form>
+
+      <p>
+        <a href="/raiserepair/book-appointment/">Back to book an appointment</a>
+      </p>
 
     </div>
 

--- a/app/views/raiserepair/book-appointment.html
+++ b/app/views/raiserepair/book-appointment.html
@@ -125,6 +125,10 @@
         </div>
       </form>
 
+      <p>
+        <a href="/raiserepair/search-property/">Back to find my address</a>
+      </p>
+
     </div>
 
     <div class="column-one-third">

--- a/app/views/raiserepair/describe-repair-address.html
+++ b/app/views/raiserepair/describe-repair-address.html
@@ -56,12 +56,17 @@
       </div>
     </form>
 
+    <p>
+      <a href="/raiserepair/describe-repair-contact/">Back to add contact details</a>
+    </p>
+
     </div>
 
     <div class="column-one-third">
       <aside role="submited-steps">
         <h3 class="heading-large"><span class="heading-secondary">Your report</span></h3>
         <p class="heading-small">Problem</p>
+        <p>Something else</p>
         <p>Description: {{ data['repair-describe'] }}</p>
 
       {% if data['repair-describe-photo'] %}
@@ -74,16 +79,17 @@
         <p>Tel number: {{ data['telephone-number'] }}</p>
         <p>Available for call:
 
-          {% if data['morningCall'] %}
-            morning,
-          {% endif %}
+          {% if data['morningCall'] and data['afternoonCall'] and data['schoolRun'] %}
+            8am - 5pm (avoid school run)
 
-          {% if data['afternoonCall'] %}
-            afternoon,
-          {% endif %}
+          {% elseif data['morningCall'] and not data['afternoonCall'] and not data['schoolRun'] %}
+            8am - 12pm
 
-          {% if data['schoolRun'] %}
-            avoid school run
+          {% elseif data['afternoonCall'] and not data['morningCall'] and not data['schoolRun'] %}
+            12pm - 5pm
+
+          {% elseif data['schoolRun'] and not data['afternoonCall'] and not data['morningCall'] %}
+            10am - 2pm
           {% endif %}
         </p>
 

--- a/app/views/raiserepair/describe-repair-address.html
+++ b/app/views/raiserepair/describe-repair-address.html
@@ -66,7 +66,6 @@
       <aside role="submited-steps">
         <h3 class="heading-large"><span class="heading-secondary">Your report</span></h3>
         <p class="heading-small">Problem</p>
-        <p>Something else</p>
         <p>Description: {{ data['repair-describe'] }}</p>
 
       {% if data['repair-describe-photo'] %}
@@ -79,17 +78,15 @@
         <p>Tel number: {{ data['telephone-number'] }}</p>
         <p>Available for call:
 
-          {% if data['morningCall'] and data['afternoonCall'] and data['schoolRun'] %}
-            8am - 5pm (avoid school run)
+          {% if data['morningCall'] and data['afternoonCall'] %}
+            8am - 5pm
 
-          {% elseif data['morningCall'] and not data['afternoonCall'] and not data['schoolRun'] %}
+          {% elseif data['morningCall'] and not data['afternoonCall'] %}
             8am - 12pm
 
-          {% elseif data['afternoonCall'] and not data['morningCall'] and not data['schoolRun'] %}
+          {% elseif data['afternoonCall'] and not data['morningCall'] %}
             12pm - 5pm
 
-          {% elseif data['schoolRun'] and not data['afternoonCall'] and not data['morningCall'] %}
-            10am - 2pm
           {% endif %}
         </p>
 

--- a/app/views/raiserepair/describe-repair-confirmation.html
+++ b/app/views/raiserepair/describe-repair-confirmation.html
@@ -25,9 +25,9 @@
 
           {% if data['morningCall'] and data['afternoonCall']  %}
             8am - 5pm
-          {% elif data['morningCall'] %}
+          {% elseif data['morningCall'] and not data['afternoonCall'] %}
             8am and 12pm
-          {% elif data['afternoonCall'] %}
+          {% elseif data['afternoonCall'] and not data['morningCall'] %}
             12pm and 5pm
           {% endif %}
 

--- a/app/views/raiserepair/describe-repair-confirmation.html
+++ b/app/views/raiserepair/describe-repair-confirmation.html
@@ -33,10 +33,6 @@
 
         </strong>
 
-        {% if data['schoolRun'] %}
-          (avoid school run)
-        {% endif %}
-
         to arrange a repair appointment.</p>
 
       <p><strong class="bold">If you have any questions, please call us on <span itemprop="telephone"><a href="tel:+020 8356 3691">

--- a/app/views/raiserepair/describe-repair-contact.html
+++ b/app/views/raiserepair/describe-repair-contact.html
@@ -58,12 +58,17 @@
           </div>
         </form>
 
+        <p>
+          <a href="/raiserepair/describe-repair/">Back to describe what needs to be fixed</a>
+        </p>
+
     </div>
 
     <div class="column-one-third">
       <aside role="submited-steps">
         <h3 class="heading-large"><span class="heading-secondary">Your report</span></h3>
         <p class="heading-small">Problem</p>
+        <p>Type: Something else</p>
         <p>Description: {{ data['repair-describe'] }}</p>
 
       {% if data['repair-describe-photo'] %}

--- a/app/views/raiserepair/describe-repair-contact.html
+++ b/app/views/raiserepair/describe-repair-contact.html
@@ -45,11 +45,6 @@
               <label for="afternoonCall">afternoon, 12pm - 5pm</label>
             </div>
 
-            <div class="multiple-choice">
-              <input id="schoolRun" type="checkbox" name="schoolRun" value="schoolRun">
-              <label for="schoolRun">10am - 2pm (avoiding school run)</label>
-            </div>
-
           </fieldset>
         </div>
 
@@ -68,7 +63,6 @@
       <aside role="submited-steps">
         <h3 class="heading-large"><span class="heading-secondary">Your report</span></h3>
         <p class="heading-small">Problem</p>
-        <p>Type: Something else</p>
         <p>Description: {{ data['repair-describe'] }}</p>
 
       {% if data['repair-describe-photo'] %}

--- a/app/views/raiserepair/describe-repair.html
+++ b/app/views/raiserepair/describe-repair.html
@@ -57,7 +57,7 @@
       </form>
 
       <p>
-        <a href="/raiserepair/what-is-problem/">Back to what do you need to be fixed</a>
+        <a href="/raiserepair/what-is-problem/">Back to 'what do you need to be fixed'</a>
       </p>
 
     </div>
@@ -65,8 +65,6 @@
     <div class="column-one-third">
       <aside role="submited-steps">
         <h3 class="heading-large"><span class="heading-secondary">Your report</span></h3>
-        <p class="heading-small">Problem</p>
-        <p>Type: Something else</p>
       </aside>
     </div>
 <!--

--- a/app/views/raiserepair/describe-repair.html
+++ b/app/views/raiserepair/describe-repair.html
@@ -16,7 +16,7 @@
 
       <form action="/raiserepair/describe-repair-contact" method="post" class="form">
         <h2 class="heading-medium">
-          Please describe what is wrong
+          Please describe what needs to be fixed
         </h2>
 
         <div class="form-group">
@@ -55,6 +55,19 @@
         </div>
 
       </form>
+
+      <p>
+        <a href="/raiserepair/what-is-problem/">Back to what do you need to be fixed</a>
+      </p>
+
+    </div>
+
+    <div class="column-one-third">
+      <aside role="submited-steps">
+        <h3 class="heading-large"><span class="heading-secondary">Your report</span></h3>
+        <p class="heading-small">Problem</p>
+        <p>Type: Something else</p>
+      </aside>
     </div>
 <!--
     <div class="column-one-third">

--- a/app/views/raiserepair/repair-details.html
+++ b/app/views/raiserepair/repair-details.html
@@ -56,7 +56,7 @@
 
       </form>
       <p>
-        <a href="/raiserepair/what-is-problem/">Back to what do you need to be fixed</a>
+        <a href="/raiserepair/what-is-problem/">Back to 'what do you need to be fixed'</a>
       </p>
     </div>
 

--- a/app/views/raiserepair/repair-details.html
+++ b/app/views/raiserepair/repair-details.html
@@ -55,7 +55,19 @@
         </div>
 
       </form>
+      <p>
+        <a href="/raiserepair/what-is-problem/">Back to what do you need to be fixed</a>
+      </p>
     </div>
+
+    <div class="column-one-third">
+      <aside role="submited-steps">
+        <h3 class="heading-large"><span class="heading-secondary">Your report</span></h3>
+        <p class="heading-small">Problem</p>
+        <p>Type: {{ data ['commonRepair'] }}</p>
+      </aside>
+    </div>
+
 <!--
     <div class="column-one-third">
       <aside role="submited-steps">

--- a/app/views/raiserepair/search-property.html
+++ b/app/views/raiserepair/search-property.html
@@ -55,11 +55,9 @@
         </div>
       </form>
 
-      <!-- <form action="/raiserepair/cannot-find-property" method="post" class="form inline"> -->
-      <!--   <div class="form-group inline"> -->
-      <!--     <input class="button" type="submit" value="My address isn't here"> -->
-      <!--   </div> -->
-      <!-- </form> -->
+      <p>
+        <a href="/raiserepair/repair-details/">Back to add repair details</a>
+      </p>
 
     </div>
 

--- a/app/views/raiserepair/what-is-problem.html
+++ b/app/views/raiserepair/what-is-problem.html
@@ -52,7 +52,7 @@
             <div class="multiple-choice"></div>
 
             <div class="multiple-choice" data-target="show-not-on-the-list">
-              <input id="none" type="radio" name="commonRepair" value="none">
+              <input id="none" type="radio" name="commonRepair" value="Something else">
               <label for="none">Something else</label>
             </div>
 
@@ -74,6 +74,10 @@
           </div>
         </form>
       </div>
+
+      <p>
+        <a href="/raiserepair/start/">Back to start</a>
+      </p>
 
     </div>
 <!--


### PR DESCRIPTION
During user testing we have discovered a user need to go back to previous page.

Added back links at the end of raise repair pages. This gives the
user the ability to go back and edit their input.

Added improvements to booking call back time logic. We have decided that for picking a call back slots it's better if don't use "avoid school run ". Because in this scenario it's more likely that a person can answer the phone during that time. And this removes complexity.

Improve the wording to add more clarity.