### PR TITLE
[68] Split address lookup across two pages

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -10,6 +10,10 @@ $path: "/public/images/";
 @import 'patterns/check-your-answers';
 @import 'patterns/task-list';
 
+strong {
+  font-weight: bold;
+}
+
 // Related items
 // (These styles will be moved to GOV.UK elements, duplicating here for now.)
 .govuk-related-items {

--- a/app/routes.js
+++ b/app/routes.js
@@ -40,8 +40,12 @@ router.get('/raiserepair/search-property', function (req, res) {
   res.render('raiserepair/search-property')
 });
 
+router.get('/raiserepair/search-property-results', function (req, res) {
+  res.render('raiserepair/search-property-results')
+});
+
 router.get('/raiserepair/describe-repair', function (req, res) {
-  res.render('raiserepair/describe-repair')
+  res.render('raiserepair/describe-repair');
 });
 
 router.get('/raiserepair/describe-repair-contact', function (req, res) {

--- a/app/views/raiserepair/describe-repair-address-results.html
+++ b/app/views/raiserepair/describe-repair-address-results.html
@@ -1,0 +1,97 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+  Hackney - Maintain My Home
+{% endblock %}
+
+{% block content %}
+
+<main id="content" role="main">
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-large">
+        Maintain My Home
+        <span class="heading-secondary">Request a repair</span>
+      </h1>
+
+      <form action="/raiserepair/describe-repair-confirmation" method="post" class="form">
+        <div class="form-group">
+          <h2 class="heading-medium">
+             What is your address?
+          </h2>
+
+          <div class="form-group">
+            <label class="form-label" for="postcode">
+              Postcode
+            </label>
+
+            <p><strong>{{ data['postcode'] | upper }}</strong> &nbsp; <a href="/raiserepair/describe-repair-address.html">Change</a></p>
+          </div>
+
+          <div class="form-group">
+            <label class="form-label" for="postcode">
+              Select an address
+            </label>
+
+            <div class="multiple-choice" data-target="select-address">
+              <input id="property1" type="radio" name="address" value="Flat 1, 8 Hoxton Square, N1 6NU">
+              <label for="property1">Flat 1, 8 Hoxton Square, N1 6NU</label>
+            </div>
+            <div class="multiple-choice" data-target="select-address">
+              <input id="property2" type="radio" name="address" value="Flat 2, 8 Hoxton Square, N1 6NU">
+              <label for="property2">Flat 2, 8 Hoxton Square, N1 6NU</label>
+            </div>
+            <div class="multiple-choice" data-target="select-address">
+              <input id="property4" type="radio" name="address" value="Flat 4, 8 Hoxton Square, N1 6NU">
+              <label for="property4">Flat 4, 8 Hoxton Square, N1 6NU</label>
+            </div>
+            <div class="multiple-choice" data-target="select-address">
+              <input id="property5" type="radio" name="address" value="Flat 5, 8 Hoxton Square, N1 6NU">
+              <label for="property5">Flat 5, 8 Hoxton Square, N1 6NU</label>
+            </div>
+
+            <div class="multiple-choice"></div>
+
+            <div class="multiple-choice" data-target="address-not-here">
+              <input id="property0" type="radio" name="address" value="N/A">
+              <label for="property0">My address isn't here</label>
+            </div>
+
+            <div class="form-group js-hidden" id="select-address">
+              <br />
+              <input class="button" type="submit" value="Use this address">
+            </div>
+
+            <div class="form-group js-hidden" id="address-not-here">
+              <br />
+              <a href="/raiserepair/cannot-find-property" class="button">Use this address</a>
+            </div>
+          </div>
+        </div>
+      </form>
+
+
+      <p>
+        <a href="/raiserepair/describe-repair-address/">Back to property search</a>
+      </p>
+
+    </div>
+
+    <div class="column-one-third">
+      <aside role="submited-steps">
+        <h3 class="heading-large"><span class="heading-secondary">Your report</span></h3>
+        <p class="heading-small">Problem</p>
+        <p>Type: {{ data ['commonRepair'] }}</p>
+        {% if data ['repair-notes'] %}
+        <p>Description: {{ data ['repair-notes'] }}</p>
+        {% endif %}
+      </aside>
+    </div>
+  </div>
+</main>
+
+{% endblock %}
+
+{% block scripts %}
+  {% include "includes/scripts.html" %}
+{% endblock %}

--- a/app/views/raiserepair/describe-repair-address.html
+++ b/app/views/raiserepair/describe-repair-address.html
@@ -14,51 +14,28 @@
         <span class="heading-secondary">Request a repair</span>
       </h1>
 
-    <!-- <form action="/raiserepair/describe-repair-confirmation" method="post"  -->
-    <form action="/raiserepair/describe-repair-confirmation" method="post" class="form">
-      <div class="form-group">
-        <h2 class="heading-medium">
-           What is your address?
-        </h2>
-
+      <form action="/raiserepair/describe-repair-address-results" method="post" class="form">
         <div class="form-group">
-          <label class="form-label" for="postcode">
-            Search for your address by postcode
-          </label>
-          <input class="form-control" id="postcode" type="text" name="postcode">
-          <a class="button" id="address-selection-button" data-target="address-selection-two">Find my address</a>
-        </div>
+          <h2 class="heading-medium">
+            What is your address?
+          </h2>
 
-        <div class="form-group js-hidden" id="address-selection-two">
-          <div class="multiple-choice">
-            <input id="property1" type="radio" name="address" value="Flat 1, 8 Hoxton Square, N1 6NU">
-            <label for="property1">Flat 1, 8 Hoxton Square, N1 6NU</label>
-          </div>
-          <div class="multiple-choice">
-            <input id="property1" type="radio" name="address" value="Flat 2, 8 Hoxton Square, N1 6NU">
-            <label for="property1">Flat 2, 8 Hoxton Square, N1 6NU</label>
-          </div>
-          <div class="multiple-choice">
-            <input id="property1" type="radio" name="address" value="Flat 4, 8 Hoxton Square, N1 6NU">
-            <label for="property1">Flat 4, 8 Hoxton Square, N1 6NU</label>
-          </div>
-          <div class="multiple-choice">
-            <input id="property1" type="radio" name="address" value="Flat 5, 8 Hoxton Square, N1 6NU">
-            <label for="property1">Flat 5, 8 Hoxton Square, N1 6NU</label>
-          </div>
           <div class="form-group">
-            <input class="button" type="submit" value="Use this address">
+            <label class="form-label" for="postcode">
+              Postcode
+            </label>
+            <input class="form-control" id="postcode" type="text" name="postcode" value="{{ data ['postcode'] }}">
           </div>
+
           <div class="form-group">
-            <a href="/raiserepair/cannot-find-property" class="button">My address isn't here</a>
+            <input class="button" type="submit" value="Find my address">
           </div>
         </div>
-      </div>
-    </form>
+      </form>
 
-    <p>
+      <p>
       <a href="/raiserepair/describe-repair-contact/">Back to add contact details</a>
-    </p>
+      </p>
 
     </div>
 
@@ -68,11 +45,10 @@
         <p class="heading-small">Problem</p>
         <p>Description: {{ data['repair-describe'] }}</p>
 
-      {% if data['repair-describe-photo'] %}
+        {% if data['repair-describe-photo'] %}
+          <p>Photo: {{ data['repair-describe-photo'] }}</p>
+        {% endif %}
 
-        <p>Photo: {{ data['repair-describe-photo'] }}</p>
-
-      {% endif %}
         <p class="heading-small">Contact details</p>
         <p>Full Name: {{ data['full-name'] }}</p>
         <p>Tel number: {{ data['telephone-number'] }}</p>

--- a/app/views/raiserepair/search-property-results.html
+++ b/app/views/raiserepair/search-property-results.html
@@ -1,0 +1,97 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+  Hackney - Maintain My Home
+{% endblock %}
+
+{% block content %}
+
+<main id="content" role="main">
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-large">
+        Maintain My Home
+        <span class="heading-secondary">Request a repair</span>
+      </h1>
+
+      <form action="/raiserepair/book-appointment" method="post" class="form">
+        <div class="form-group">
+          <h2 class="heading-medium">
+             What is your address?
+          </h2>
+
+          <div class="form-group">
+            <label class="form-label" for="postcode">
+              Postcode
+            </label>
+
+            <p><strong>{{ data['postcode'] | upper }}</strong> &nbsp; <a href="/raiserepair/search-property.html">Change</a></p>
+          </div>
+
+          <div class="form-group">
+            <label class="form-label" for="postcode">
+              Select an address
+            </label>
+
+            <div class="multiple-choice" data-target="select-address">
+              <input id="property1" type="radio" name="address" value="Flat 1, 8 Hoxton Square, N1 6NU">
+              <label for="property1">Flat 1, 8 Hoxton Square, N1 6NU</label>
+            </div>
+            <div class="multiple-choice" data-target="select-address">
+              <input id="property2" type="radio" name="address" value="Flat 2, 8 Hoxton Square, N1 6NU">
+              <label for="property2">Flat 2, 8 Hoxton Square, N1 6NU</label>
+            </div>
+            <div class="multiple-choice" data-target="select-address">
+              <input id="property4" type="radio" name="address" value="Flat 4, 8 Hoxton Square, N1 6NU">
+              <label for="property4">Flat 4, 8 Hoxton Square, N1 6NU</label>
+            </div>
+            <div class="multiple-choice" data-target="select-address">
+              <input id="property5" type="radio" name="address" value="Flat 5, 8 Hoxton Square, N1 6NU">
+              <label for="property5">Flat 5, 8 Hoxton Square, N1 6NU</label>
+            </div>
+
+            <div class="multiple-choice"></div>
+
+            <div class="multiple-choice" data-target="address-not-here">
+              <input id="property0" type="radio" name="address" value="N/A">
+              <label for="property0">My address isn't here</label>
+            </div>
+
+            <div class="form-group js-hidden" id="select-address">
+              <br />
+              <input class="button" type="submit" value="Use this address">
+            </div>
+
+            <div class="form-group js-hidden" id="address-not-here">
+              <br />
+              <a href="/raiserepair/cannot-find-property" class="button">Use this address</a>
+            </div>
+          </div>
+        </div>
+      </form>
+
+
+      <p>
+        <a href="/raiserepair/repair-details/">Back to property search</a>
+      </p>
+
+    </div>
+
+    <div class="column-one-third">
+      <aside role="submited-steps">
+        <h3 class="heading-large"><span class="heading-secondary">Your report</span></h3>
+        <p class="heading-small">Problem</p>
+        <p>Type: {{ data ['commonRepair'] }}</p>
+        {% if data ['repair-notes'] %}
+        <p>Description: {{ data ['repair-notes'] }}</p>
+        {% endif %}
+      </aside>
+    </div>
+  </div>
+</main>
+
+{% endblock %}
+
+{% block scripts %}
+  {% include "includes/scripts.html" %}
+{% endblock %}

--- a/app/views/raiserepair/search-property.html
+++ b/app/views/raiserepair/search-property.html
@@ -24,7 +24,7 @@
             <label class="form-label" for="postcode">
               Postcode
             </label>
-            <input class="form-control" id="postcode" type="text" name="postcode" required>
+            <input class="form-control" id="postcode" type="text" name="postcode" value="{{ data ['postcode'] }}">
           </div>
 
           <div class="form-group">

--- a/app/views/raiserepair/search-property.html
+++ b/app/views/raiserepair/search-property.html
@@ -14,7 +14,7 @@
         <span class="heading-secondary">Request a repair</span>
       </h1>
 
-      <form action="/raiserepair/book-appointment" method="post" class="form">
+      <form action="/raiserepair/search-property-results" method="post" class="form">
         <div class="form-group">
           <h2 class="heading-medium">
              What is your address?
@@ -22,35 +22,13 @@
 
           <div class="form-group">
             <label class="form-label" for="postcode">
-              Search for your address by postcode
+              Postcode
             </label>
-            <input class="form-control" id="postcode" type="text" name="postcode">
-            <a class="button" id="address-selection-button" data-target="address-selection">Find my address</a>
+            <input class="form-control" id="postcode" type="text" name="postcode" required>
           </div>
 
-          <div class="form-group js-hidden" id="address-selection">
-            <div class="multiple-choice">
-              <input id="property1" type="radio" name="address" value="Flat 1, 8 Hoxton Square, N1 6NU">
-              <label for="property1">Flat 1, 8 Hoxton Square, N1 6NU</label>
-            </div>
-            <div class="multiple-choice">
-              <input id="property1" type="radio" name="address" value="Flat 2, 8 Hoxton Square, N1 6NU">
-              <label for="property1">Flat 2, 8 Hoxton Square, N1 6NU</label>
-            </div>
-            <div class="multiple-choice">
-              <input id="property1" type="radio" name="address" value="Flat 4, 8 Hoxton Square, N1 6NU">
-              <label for="property1">Flat 4, 8 Hoxton Square, N1 6NU</label>
-            </div>
-            <div class="multiple-choice">
-              <input id="property1" type="radio" name="address" value="Flat 5, 8 Hoxton Square, N1 6NU">
-              <label for="property1">Flat 5, 8 Hoxton Square, N1 6NU</label>
-            </div>
-            <div class="form-group">
-              <input class="button" type="submit" value="Use this address">
-            </div>
-            <div class="form-group">
-              <a href="/raiserepair/cannot-find-property" class="button">My address isn't here</a>
-            </div>
+          <div class="form-group">
+            <input class="button" type="submit" value="Find my address">
           </div>
         </div>
       </form>


### PR DESCRIPTION
As per the Rails app and the GDS pattern library, split the address lookup between two pages. The first only deals with the entry of a postcode, the second shows the postcode (with the option of changing it) and allows the user to select an address from a series of radio buttons.

https://www.gov.uk/service-manual/design/addresses#using-an-address-lookup

